### PR TITLE
Gereksiz bağımlılık sorunu çözüldü

### DIFF
--- a/kernel/linux/pspec.xml
+++ b/kernel/linux/pspec.xml
@@ -36,7 +36,6 @@
         <Name>linux</Name>
         <RuntimeDependencies>
             <Dependency>linux-firmware</Dependency>
-            <Dependency>grub2</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable" permanent="true">/boot</Path>


### PR DESCRIPTION
knk kernel neden bootloader paketine bağlı??
adam belki lilo derledi elle.
Veya başka bir linux dağıtımının kernelini kullanıyo
veya boot etcek başka yöntemi var.
Bence ubuntunun yaptığı saçmalığı yapmayak bağımlılıkları sadece çalışmaya yetecek kadar verek